### PR TITLE
Updating nan to v2.22.2 to support Node.js v24 with node-expat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: ['lts/*']
+                node-version: ['lts/*', '24']
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@
 name: build
 
 on:
+    workflow_dispatch:
     schedule:
         - cron: '0 0 1 * *'
     push:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "reponame": "xml2json",
         "build": true
     },
-    "version": "2025.4.122",
+    "version": "2025.4.123",
     "description": "🔁 Converts xml to json and vice-versa, using node-expat",
     "repository": {
         "type": "git",
@@ -24,7 +24,7 @@
     "dependencies": {
         "@hapi/hoek": "^11.0.7",
         "joi": "^17.13.3",
-        "nan": "^2.22.0",
+        "nan": "^2.22.2",
         "node-expat": "^2.4.1"
     },
     "bin": {


### PR DESCRIPTION
- Updated **nan** to v2.22.2 to support Node.js v24. **nan** v2.22.0 throws errors when compiling `node-expat` with Node.js v24.
- Added Node.js v24 to GitHub Action - to be removed once v24 moves to LTS.
- Added manual trigger to GitHub Action for easier testing.